### PR TITLE
Add burp-converter plugin

### DIFF
--- a/packages/burp-converter/package.json
+++ b/packages/burp-converter/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@seleniumhq/burp-converter",
+  "version": "4.0.13",
+  "private": true,
+  "description": "Selenium IDE plugin that annotates recorded commands",
+  "author": "SeleniumHQ",
+  "homepage": "http://github.com/SeleniumHQ/selenium-ide",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo node_modules",
+    "watch": "tsc --watch"
+  },
+  "devDependencies": {
+    "@seleniumhq/side-api": "4.0.13"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SeleniumHQ/selenium-ide.git"
+  },
+  "bugs": {
+    "url": "https://github.com/SeleniumHQ/selenium-ide/issues"
+  }
+}

--- a/packages/burp-converter/src/index.ts
+++ b/packages/burp-converter/src/index.ts
@@ -1,0 +1,5 @@
+import { PluginShape } from '@seleniumhq/side-api'
+
+const plugin: PluginShape = {}
+
+export default plugin

--- a/packages/burp-converter/src/preload/index.ts
+++ b/packages/burp-converter/src/preload/index.ts
@@ -1,0 +1,16 @@
+import { Api } from '@seleniumhq/side-api'
+
+// @ts-expect-error - sideAPI is injected at runtime
+const api = window.sideAPI as Api
+
+api.plugins.addRecorderPreprocessor((command) => {
+  return {
+    action: 'update',
+    command: {
+      ...command,
+      comment: 'plugin active',
+    },
+  }
+})
+
+export = true

--- a/packages/burp-converter/tsconfig.json
+++ b/packages/burp-converter/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/__mocks__"],
+  "references": [
+    {
+      "path": "../side-api"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,9 @@
     },
     {
       "path": "./packages/webdriver-testkit"
+    },
+    {
+      "path": "./packages/burp-converter"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add burp-converter plugin that adds a comment on every recorded command
- expose plugin as its own package and update tsconfig references

## Testing
- `npm run lint:scripts` *(fails: Cannot read config file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685b05dd8fcc83259ac0f71883b19c16